### PR TITLE
Add support for withdrawing notes from bank

### DIFF
--- a/src/main/java/com/example/InteractionApi/BankInteraction.java
+++ b/src/main/java/com/example/InteractionApi/BankInteraction.java
@@ -15,6 +15,12 @@ public class BankInteraction {
     private static final int WITHDRAW_AS_VARBIT = 3958;
     private static final int WITHDRAW_ITEM_MODE = 0;
     private static final int WITHDRAW_NOTES_MODE = 1;
+    private static final int WITHDRAW_ITEM_MODE_WIDGET = 786454;
+    private static final int WITHDRAW_NOTE_MODE_WIDGET = 786456;
+
+    private static final String ITEM_MODE_ACTION = "Item";
+    private static final String NOTE_MODE_ACTION = "Note";
+
 
     public static boolean useItem(String name, boolean noted, String... actions) {
         return Bank.search().withName(name).first().flatMap(item ->
@@ -89,8 +95,8 @@ public class BankInteraction {
 
     public static boolean setWithdrawMode(boolean noted) {
         int withdrawAsVarbitValue = EthanApiPlugin.getClient().getVarbitValue(WITHDRAW_AS_VARBIT);
-        Optional<Widget> itemWidget = Widgets.search().withId(786454).withAction("Item").first();
-        Optional<Widget> noteWidget = Widgets.search().withId(786456).withAction("Note").first();
+        Optional<Widget> itemWidget = Widgets.search().withId(WITHDRAW_ITEM_MODE_WIDGET).withAction(ITEM_MODE_ACTION).first();
+        Optional<Widget> noteWidget = Widgets.search().withId(WITHDRAW_NOTE_MODE_WIDGET).withAction(NOTE_MODE_ACTION).first();
         if (itemWidget.isEmpty() || noteWidget.isEmpty()) {
             return false;
         }

--- a/src/main/java/com/example/InteractionApi/BankInteraction.java
+++ b/src/main/java/com/example/InteractionApi/BankInteraction.java
@@ -1,6 +1,7 @@
 package com.example.InteractionApi;
 
 import com.example.EthanApiPlugin.Collections.Bank;
+import com.example.EthanApiPlugin.Collections.Widgets;
 import com.example.EthanApiPlugin.EthanApiPlugin;
 import com.example.Packets.MousePackets;
 import com.example.Packets.WidgetPackets;
@@ -11,62 +12,103 @@ import java.util.function.Predicate;
 
 public class BankInteraction {
     private static final int WITHDRAW_QUANTITY = 3960;
+    private static final int WITHDRAW_AS_VARBIT = 3958;
+    private static final int WITHDRAW_ITEM_MODE = 0;
+    private static final int WITHDRAW_NOTES_MODE = 1;
 
-    public static boolean useItem(String name, String... actions) {
+    public static boolean useItem(String name, boolean noted, String... actions) {
         return Bank.search().withName(name).first().flatMap(item ->
         {
+            setWithdrawMode(noted);
+
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetAction(item, actions);
             return Optional.of(true);
         }).orElse(false);
     }
 
-    public static boolean useItem(int id, String... actions) {
+    public static boolean useItem(int id, boolean noted, String... actions) {
         return Bank.search().withId(id).first().flatMap(item ->
         {
+            setWithdrawMode(noted);
+
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetAction(item, actions);
             return Optional.of(true);
         }).orElse(false);
     }
 
-    public static boolean useItem(Predicate<? super Widget> predicate, String... actions) {
+    public static boolean useItem(Predicate<? super Widget> predicate, boolean noted, String... actions) {
         return Bank.search().filter(predicate).first().flatMap(item ->
         {
+            setWithdrawMode(noted);
+
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetAction(item, actions);
             return Optional.of(true);
         }).orElse(false);
     }
 
-    public static void withdrawX(Widget item, int amount) {
+    public static void withdrawX(Widget item, int amount, boolean noted) {
+        setWithdrawMode(noted);
+
         if (EthanApiPlugin.getClient().getVarbitValue(WITHDRAW_QUANTITY) == amount) {
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetActionPacket(5, item.getId(), item.getItemId(), item.getIndex());
             return;
         }
-        BankInteraction.useItem(item, "Withdraw-X");
+        BankInteraction.useItem(item, noted, "Withdraw-X");
         EthanApiPlugin.getClient().setVarcStrValue(359, Integer.toString(amount));
         EthanApiPlugin.getClient().setVarcIntValue(5, 7);
         EthanApiPlugin.getClient().runScript(681);
         EthanApiPlugin.getClient().setVarbit(WITHDRAW_QUANTITY, amount);
     }
 
-    public static boolean useItemIndex(int index, String... actions) {
+    public static boolean useItemIndex(int index, boolean noted, String... actions) {
         return Bank.search().indexIs(index).first().flatMap(item ->
         {
+            setWithdrawMode(noted);
+
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetAction(item, actions);
             return Optional.of(true);
         }).orElse(false);
     }
 
-    public static boolean useItem(Widget item, String... actions) {
+    public static boolean useItem(Widget item, boolean noted, String... actions) {
         if (item == null) {
             return false;
         }
+
+        setWithdrawMode(noted);
+
         MousePackets.queueClickPacket();
         WidgetPackets.queueWidgetAction(item, actions);
         return true;
+    }
+
+    public static boolean setWithdrawMode(boolean noted) {
+        int withdrawAsVarbitValue = EthanApiPlugin.getClient().getVarbitValue(WITHDRAW_AS_VARBIT);
+        Optional<Widget> itemWidget = Widgets.search().withId(786454).withAction("Item").first();
+        Optional<Widget> noteWidget = Widgets.search().withId(786456).withAction("Note").first();
+        if (itemWidget.isEmpty() || noteWidget.isEmpty()) {
+            return false;
+        }
+
+        if (noted && withdrawAsVarbitValue == WITHDRAW_ITEM_MODE) {
+            MousePackets.queueClickPacket();
+            WidgetPackets.queueWidgetAction(noteWidget.get(), "Note");
+
+            return true;
+        }
+
+        if (!noted && withdrawAsVarbitValue == WITHDRAW_NOTES_MODE) {
+            MousePackets.queueClickPacket();
+            WidgetPackets.queueWidgetAction(itemWidget.get(), "Item");
+
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Added a `noted` flag to members of `BankInteraction` so that items can be withdrawn either noted or as item.