### PR TITLE
Fix keyCode on KeyEvent keyTyped

### DIFF
--- a/src/main/java/com/example/Packets/MousePackets.java
+++ b/src/main/java/com/example/Packets/MousePackets.java
@@ -84,7 +84,7 @@ public class MousePackets{
         client.getCanvas().dispatchEvent(keyPress);
         KeyEvent keyRelease = new KeyEvent(client.getCanvas(), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_BACK_SPACE);
         client.getCanvas().dispatchEvent(keyRelease);
-        KeyEvent keyTyped = new KeyEvent(client.getCanvas(), KeyEvent.KEY_TYPED, System.currentTimeMillis(), 0, KeyEvent.VK_BACK_SPACE);
+        KeyEvent keyTyped = new KeyEvent(client.getCanvas(), KeyEvent.KEY_TYPED, System.currentTimeMillis(), 0, KeyEvent.VK_UNDEFINED);
         client.getCanvas().dispatchEvent(keyTyped);
     }
     @SneakyThrows


### PR DESCRIPTION
keyCode is never used anyway in KeyEvent and gives some users an java.lang.IllegalArgumentException: invalid keyCode.