### PR TITLE
Fix withdrawX again and widgetOnTileObject

### DIFF
--- a/src/main/java/com/example/InteractionApi/BankInteraction.java
+++ b/src/main/java/com/example/InteractionApi/BankInteraction.java
@@ -60,16 +60,10 @@ public class BankInteraction {
     public static void withdrawX(Widget item, int amount) {
         setWithdrawMode(EthanApiPlugin.getClient().getVarbitValue(WITHDRAW_AS_VARBIT));
 
-        if (EthanApiPlugin.getClient().getVarbitValue(Varbits.BANK_REQUESTEDQUANTITY) == amount) {
-            MousePackets.queueClickPacket();
-            WidgetPackets.queueWidgetActionPacket(5, item.getId(), item.getItemId(), item.getIndex());
-            return;
-        }
-
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetAction(item, "Withdraw-X");
+        WidgetPackets.queueWidgetActionPacket(4, item.getId(),
+                item.getItemId(), item.getIndex());
         WidgetPackets.queueResumeCount(amount);
-        EthanApiPlugin.getClient().setVarbit(Varbits.BANK_REQUESTEDQUANTITY, amount);
     }
 
     public static boolean useItemIndex(int index, String... actions) {
@@ -131,16 +125,10 @@ public class BankInteraction {
     public static void withdrawX(Widget item, int amount, boolean noted) {
         setWithdrawMode(noted? WITHDRAW_NOTES_MODE : WITHDRAW_ITEM_MODE);
 
-        if (EthanApiPlugin.getClient().getVarbitValue(Varbits.BANK_REQUESTEDQUANTITY) == amount) {
-            MousePackets.queueClickPacket();
-            WidgetPackets.queueWidgetActionPacket(5, item.getId(), item.getItemId(), item.getIndex());
-            return;
-        }
-
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetAction(item, "Withdraw-X");
+        WidgetPackets.queueWidgetActionPacket(4, item.getId(),
+                item.getItemId(), item.getIndex());
         WidgetPackets.queueResumeCount(amount);
-        EthanApiPlugin.getClient().setVarbit(Varbits.BANK_REQUESTEDQUANTITY, amount);
     }
 
     public static boolean useItemIndex(int index, boolean noted, String... actions) {

--- a/src/main/java/com/example/PacketUtils/ObfuscatedNames.java
+++ b/src/main/java/com/example/PacketUtils/ObfuscatedNames.java
@@ -259,9 +259,9 @@ public final class ObfuscatedNames {
     public static final String OPLOCT_METHOD_NAME4 = "bc";
     public static final String OPLOCT_WRITE5 = "worldPointY";
     public static final String OPLOCT_METHOD_NAME5 = "bs";
-    public static final String OPLOCT_WRITE6 = "objectId";
+    public static final String OPLOCT_WRITE6 = "itemId";
     public static final String OPLOCT_METHOD_NAME6 = "ed";
-    public static final String OPLOCT_WRITE7 = "itemId";
+    public static final String OPLOCT_WRITE7 = "objectId";
     public static final String OPLOCT_METHOD_NAME7 = "du";
     public static final String[][] OPLOCT_WRITES = new String[][]{
             {"r 8", "v"},


### PR DESCRIPTION
Previous version of `withdrawX` again only partially worked, it would fail after it was called causing menu options to get mixed up or something.  Not really sure what was happening there, went with the more primitive approach:

```
        MousePackets.queueClickPacket();
        WidgetPackets.queueWidgetActionPacket(4, item.getId(),
                item.getItemId(), item.getIndex());
        WidgetPackets.queueResumeCount(amount);
```

Seems to have fixed our problems for good this time lol.

I also found a bug where my updater mixed up `objectId` and `itemId` when mapping `OPLOCT`

Thoroughly tested, tried to break it intentionally.  Promise it's good this time