### PR TITLE
BankItemWidget and GE fixes

### DIFF
--- a/src/main/java/com/example/EthanApiPlugin/Collections/BankItemWidget.java
+++ b/src/main/java/com/example/EthanApiPlugin/Collections/BankItemWidget.java
@@ -436,6 +436,7 @@ public class BankItemWidget implements Widget {
     @Nullable
     @Override
     public String[] getActions() {
+        int xQuantity = EthanApiPlugin.getClient().getVarbitValue(VarbitID.BANK_REQUESTEDQUANTITY);
         String[] actions = new String[10];
         switch (EthanApiPlugin.getClient().getVarbitValue(VarbitID.BANK_QUANTITY_TYPE)) {
             default:
@@ -443,31 +444,50 @@ public class BankItemWidget implements Widget {
                 actions[0] = "Withdraw-1";
                 actions[1] = "Withdraw-5";
                 actions[2] = "Withdraw-10";
-                actions[3] = "Withdraw-" + EthanApiPlugin.getClient().getVarbitValue(VarbitID.BANK_REQUESTEDQUANTITY);
-                actions[4] = "Withdraw-X";
-                actions[5] = "Withdraw-All";
-                actions[6] = "Withdraw-All-but-1";
+                if (xQuantity > 0) {
+                    actions[3] = "Withdraw-" + xQuantity;
+                    actions[4] = "Withdraw-X";
+                    actions[5] = "Withdraw-All";
+                    actions[6] = "Withdraw-All-but-1";
+                } else {
+                    actions[3] = "Withdraw-X";
+                    actions[4] = "Withdraw-All";
+                    actions[5] = "Withdraw-All-but-1";
+                }
                 break;
             case 1:
                 actions[0] = "Withdraw-5";
                 actions[1] = "Withdraw-1";
                 actions[2] = "Withdraw-10";
-                actions[3] = "Withdraw-" + EthanApiPlugin.getClient().getVarbitValue(VarbitID.BANK_REQUESTEDQUANTITY);
-                actions[4] = "Withdraw-X";
-                actions[5] = "Withdraw-All";
-                actions[6] = "Withdraw-All-but-1";
+                if (xQuantity > 0) {
+                    actions[3] = "Withdraw-" + xQuantity;
+                    actions[4] = "Withdraw-X";
+                    actions[5] = "Withdraw-All";
+                    actions[6] = "Withdraw-All-but-1";
+                } else {
+                    actions[3] = "Withdraw-X";
+                    actions[4] = "Withdraw-All";
+                    actions[5] = "Withdraw-All-but-1";
+                }
                 break;
             case 2:
                 actions[0] = "Withdraw-10";
                 actions[1] = "Withdraw-1";
                 actions[2] = "Withdraw-5";
-                actions[3] = "Withdraw-" + EthanApiPlugin.getClient().getVarbitValue(VarbitID.BANK_REQUESTEDQUANTITY);
-                actions[4] = "Withdraw-X";
-                actions[5] = "Withdraw-All";
-                actions[6] = "Withdraw-All-but-1";
+                if (xQuantity > 0) {
+                    actions[3] = "Withdraw-" + xQuantity;
+                    actions[4] = "Withdraw-X";
+                    actions[5] = "Withdraw-All";
+                    actions[6] = "Withdraw-All-but-1";
+                } else {
+                    actions[3] = "Withdraw-X";
+                    actions[4] = "Withdraw-All";
+                    actions[5] = "Withdraw-All-but-1";
+                }
                 break;
             case 3:
-                actions[0] = "Withdraw-" + EthanApiPlugin.getClient().getVarbitValue(VarbitID.BANK_REQUESTEDQUANTITY);
+                // this can't ever be a thing while this is set to 0
+                actions[0] = "Withdraw-" + xQuantity;
                 actions[1] = "Withdraw-1";
                 actions[2] = "Withdraw-5";
                 actions[3] = "Withdraw-10";
@@ -480,9 +500,14 @@ public class BankItemWidget implements Widget {
                 actions[1] = "Withdraw-1";
                 actions[2] = "Withdraw-5";
                 actions[3] = "Withdraw-10";
-                actions[4] = "Withdraw-" + EthanApiPlugin.getClient().getVarbitValue(VarbitID.BANK_REQUESTEDQUANTITY);
-                actions[5] = "Withdraw-X";
-                actions[6] = "Withdraw-All-but-1";
+                if (xQuantity > 0) {
+                    actions[4] = "Withdraw-" + xQuantity;
+                    actions[5] = "Withdraw-X";
+                    actions[6] = "Withdraw-All-but-1";
+                } else {
+                    actions[4] = "Withdraw-X";
+                    actions[5] = "Withdraw-All-but-1";
+                }
                 break;
         }
 

--- a/src/main/java/com/example/EthanApiPlugin/Collections/GrandExchange.java
+++ b/src/main/java/com/example/EthanApiPlugin/Collections/GrandExchange.java
@@ -9,6 +9,7 @@ import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.WorldType;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.RuneLite;
@@ -30,11 +31,22 @@ public class GrandExchange {
     private static final Client client = RuneLite.getInjector().getInstance(Client.class);
 
 
+    /**
+     * Checks if the Grand Exchange offer slots are full.
+     * @return true if the slots are full, false otherwise.
+     */
     public static boolean isFull() {
         boolean isMember = client.getWorldType().contains(WorldType.MEMBERS);
         return getOffers().size() > (isMember ? (P2P_SLOTS - 1) : (F2P_SLOTS - 1));
     }
 
+    /**
+     * Starts a buy offer in the Grand Exchange.
+     * @param itemId the ID of the item to buy.
+     * @param amount the number of items to buy.
+     * @param percentIncrease positive for increasing the price by 5%,
+     *                            negative for decreasing by 5%.
+     */
     public static void startBuyOffer(int itemId, int amount, int percentIncrease, boolean thirty) {
         if (!isOpen() || isFull()) {
             return;
@@ -52,24 +64,25 @@ public class GrandExchange {
         }
 
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, slot.getId(), -1, slot.getBuyChild());
-        setItem(itemId);
-        setItemQuantity(amount);
+        WidgetPackets.queueWidgetActionPacket(1, slot.getId(), -1, slot.getBuyChild());  // Select free slot
+        setItem(itemId);  // Set item to buy
+        setItemQuantity(amount);  // Set quantity to buy
 
-        int difference;
+        int ticker;
         if (percentIncrease < 0) {
-            difference = thirty ? 56 : 10;
+            ticker = thirty ? 56 : 10;
             percentIncrease = percentIncrease * -1;
         } else {
-            difference = thirty ? 57 : 13;
+            ticker = thirty ? 57 : 13;
         }
         int finalFive = percentIncrease;
 
         for (int i = 0; i < finalFive; i++) {
             MousePackets.queueClickPacket();
-            WidgetPackets.queueWidgetActionPacket(1, 30474265, -1, difference);
+            WidgetPackets.queueWidgetActionPacket(1, InterfaceID.GeOffers.SETUP_DESC, -1, ticker);  // Adjust price
         }
 
+        // Confirm the offer
         Widgets.search().withAction("Confirm").first().ifPresent(widget -> {
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetActionPacket(1, widget.getId(), -1, -1);
@@ -93,9 +106,9 @@ public class GrandExchange {
 
         MousePackets.queueClickPacket();
         WidgetPackets.queueWidgetActionPacket(1, slot.getId(), -1, slot.getBuyChild());
-        setItem(itemId);
+        setItem(itemId);  // Set item to buy
         setItemPrice(price);
-        setItemQuantity(amount);
+        setItemQuantity(amount);  // Set quantity to buy
         Widgets.search().withAction("Confirm").first().ifPresent(w -> {
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetActionPacket(1, w.getId(), -1, -1);
@@ -104,6 +117,13 @@ public class GrandExchange {
         return true;
     }
 
+    /**
+     * Starts a buy offer based on the item name (supports wildcards).
+     * @param itemName the name of the item to buy (case insensitive, supports wildcard *).
+     * @param amount the number of items to buy.
+     * @param fivePercentIncrease positive for increasing the price by 5%,
+     *                            negative for decreasing by 5%.
+     */
     public static void startBuyOffer(String itemName, int amount, int fivePercentIncrease) {
         Map.Entry<Integer, ItemComposition> entry = EthanApiPlugin.itemDefs.asMap()
                 .entrySet()
@@ -112,13 +132,18 @@ public class GrandExchange {
                 .findFirst().orElse(null);
 
         if (entry == null) {
-            return;
+            return;  // Item not found
         }
 
         startBuyOffer(entry.getValue().getId(), amount, fivePercentIncrease, false);
     }
 
-
+    /**
+     * Starts a sell offer for all of a specific item in the inventory.
+     * @param widget the widget representing the item in the inventory.
+     * @param percentChange positive for increasing the price by 5%,
+     *                            negative for decreasing by 5%.
+     */
     public static void startSellOffer(Widget widget, int percentChange, boolean thirty) {
         if (!isOpen() || isFull()) {
             return;
@@ -142,103 +167,99 @@ public class GrandExchange {
         MousePackets.queueClickPacket();
         WidgetPackets.queueWidgetActionPacket(1, slot.getId(), -1, slot.getSellChild());
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, ComponentID.GRAND_EXCHANGE_INVENTORY_INVENTORY_ITEM_CONTAINER, itemId, widget.getIndex());
+        WidgetPackets.queueWidgetActionPacket(1, InterfaceID.GeOffersSide.ITEMS, itemId, widget.getIndex());
 
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, 30474265, -1, 6);
+        WidgetPackets.queueWidgetActionPacket(1, InterfaceID.GeOffers.SETUP_DESC, -1, 6);  // Adjust price
 
-        int difference;
+        int ticker;
         if (percentChange < 0) {
-            difference = thirty ? 56 : 10;
-            percentChange = Math.abs(percentChange);
+            ticker = thirty ? 56 : 10;
+            percentChange = percentChange * -1;
         } else {
-            difference = thirty ? 57 : 13;
+            ticker = thirty ? 57 : 13;
         }
         int finalFive = percentChange;
 
         for (int i = 0; i < finalFive; i++) {
             MousePackets.queueClickPacket();
-            WidgetPackets.queueWidgetActionPacket(1, 30474265, -1, difference);
+            WidgetPackets.queueWidgetActionPacket(1, InterfaceID.GeOffers.SETUP_DESC, -1, ticker);  // Adjust price
         }
 
+        // Confirm the offer
         Widgets.search().withAction("Confirm").first().ifPresent(w -> {
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetActionPacket(1, w.getId(), -1, -1);
         });
     }
 
-    public static void startSellOfferPrice(Widget widget, int price) {
-        startSellOfferPrice(widget, -1, price);
-    }
-
-    public static void startSellOfferPrice(Widget widget, int amount, int price) {
-        int slotNumber = freeSlot();
-
-        if (slotNumber == -1) {
-            return;
-        }
-
-        GrandExchangeSlot slot = GrandExchangeSlot.getBySlot(slotNumber);
-        if (slot == null) {
-            return;
-        }
-
-        int itemId = widget.getItemId();
-
-        MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, slot.getId(), -1, slot.getSellChild());
-        MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, ComponentID.GRAND_EXCHANGE_INVENTORY_INVENTORY_ITEM_CONTAINER, itemId, widget.getIndex());
-
-        MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, 30474265, -1, 12);
-        WidgetPackets.queueResumeCount(price);
-        if (amount != -1) {
-            MousePackets.queueClickPacket();
-            WidgetPackets.queueWidgetActionPacket(1, 30474265, -1, 7);
-            WidgetPackets.queueResumeCount(amount);
-        }
-        MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, 30474269, -1, -1);
-    }
-
     public static void startSellOffer(Widget widget, int fivePercentDecrease) {
         startSellOffer(widget, fivePercentDecrease, false);
     }
 
-
+    /**
+     * Checks if the Grand Exchange window is currently open and visible.
+     * @return true if the window is open, false otherwise.
+     */
     public static boolean isOpen() {
         return getPage() != Page.CLOSED && getPage() != Page.UNKNOWN;
     }
 
+    /**
+     * Checks if the Grand Exchange offer window (buying/selling) is currently open.
+     * @return true if an offer window is open, false otherwise.
+     */
     public static boolean isOfferOpen() {
         return getPage() == Page.BUYING || getPage() == Page.SELLING;
     }
 
+    /**
+     * Retrieves a list of all active Grand Exchange offers.
+     * @return a list of active Grand Exchange offers.
+     */
     public static List<GrandExchangeOffer> getOffers() {
         return Arrays.stream(client.getGrandExchangeOffers())
                 .filter(offer -> offer.getItemId() > 0)
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks if there are any active offers in the Grand Exchange.
+     * @return true if there are no offers, false otherwise.
+     */
     public static boolean isEmpty() {
         return getOffers().isEmpty();
     }
 
+    /**
+     * Interacts with the 'Collect' button in the Grand Exchange to collect all items.
+     * Does not check for offer status or visibility beforehand.
+     */
     public static void collectAll() {
         if (!readyToCollect()) {
-            return;
+            return;  // No 'Collect' button found
         }
 
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, 30474246, -1, 0);
+        WidgetPackets.queueWidgetActionPacket(1, InterfaceID.GeOffers.COLLECTALL, -1, 0);  // Interact with 'Collect' button
     }
 
+    /**
+     * Checks if there are any completed offers in the Grand Exchange.
+     * @return true if there are offers ready to collect
+     */
 
     public static boolean readyToCollect() {
         return !Widgets.search().hiddenState(false).withText("Collect").empty();
     }
 
+    /**
+     * Checks if a Grand Exchange offer contains the specified item in at least the given quantity.
+     *
+     * @param itemId the ID of the item to check for
+     * @param amount the minimum quantity of the item required
+     * @return true if the item exists in any Grand Exchange offer with at least the specified quantity, false otherwise
+     */
     public static boolean hasItem(int itemId, int amount) {
         for (GrandExchangeOffer offer : getOffers()) {
             if (offer.getItemId() == itemId
@@ -250,11 +271,25 @@ public class GrandExchange {
         return false;
     }
 
+    /**
+     * Checks if a Grand Exchange offer contains the specified item in at least 1 quantity.
+     *
+     * @param itemId the ID of the item to check for
+     * @return true if the item exists in any Grand Exchange offer with at least 1 quantity, false otherwise
+     */
     public static boolean hasItem(int itemId) {
         return hasItem(itemId, 1);
     }
 
-
+    /**
+     * Checks if a Grand Exchange offer contains the specified item by name in at least the given quantity.
+     * The method first resolves the item ID by matching the item name, ignoring tags and case, and then
+     * verifies if the item is present in an offer.
+     *
+     * @param itemName the name of the item to check for
+     * @param amount the minimum quantity of the item required
+     * @return true if the item exists in any Grand Exchange offer with at least the specified quantity, false otherwise
+     */
     public static boolean hasItem(String itemName, int amount) {
         Map.Entry<Integer, ItemComposition> entry = EthanApiPlugin.itemDefs.asMap()
                 .entrySet()
@@ -270,6 +305,14 @@ public class GrandExchange {
         return hasItem(entry.getValue().getId(), amount);
     }
 
+    /**
+     * Checks if a Grand Exchange offer contains the specified item by name in at least 1 quantity.
+     * The method first resolves the item ID by matching the item name, ignoring tags and case, and then
+     * verifies if the item is present in an offer.
+     *
+     * @param itemName the name of the item to check for
+     * @return true if the item exists in any Grand Exchange offer with at least 1 quantity, false otherwise
+     */
     public static boolean hasItem(String itemName) {
         return hasItem(itemName, 1);
     }
@@ -287,7 +330,7 @@ public class GrandExchange {
         return client.getVarpValue(VarPlayer.CURRENT_GE_ITEM);
     }
 
-    private static void setItem(int id) {
+    private static void setItem(int id) { // possibly might need to invoke this on client thread
         MousePackets.queueClickPacket();
         client.runScript(754, id, 84);
     }
@@ -301,7 +344,7 @@ public class GrandExchange {
     }
 
     private static void setItemPrice(int price) {
-        Widget offerWidget = client.getWidget(ComponentID.GRAND_EXCHANGE_OFFER_CONTAINER);
+        Widget offerWidget = client.getWidget(InterfaceID.GeOffers.SETUP_DESC);
         if (offerWidget != null && offerWidget.getChild(12) != null) {
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetAction(offerWidget.getChild(12), "Enter price");
@@ -312,11 +355,11 @@ public class GrandExchange {
         }
 
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, 30474265, -1, 12);
+        WidgetPackets.queueWidgetActionPacket(1, InterfaceID.GeOffers.SETUP_DESC, -1, 12);
     }
 
     private static void setItemQuantity(int quantity) {
-        Widget offerWidget = client.getWidget(ComponentID.GRAND_EXCHANGE_OFFER_CONTAINER);
+        Widget offerWidget = client.getWidget(InterfaceID.GeOffers.SETUP_DESC);
         if (offerWidget != null && offerWidget.getChild(7) != null) {
             MousePackets.queueClickPacket();
             WidgetPackets.queueWidgetAction(offerWidget.getChild(7), "Enter quantity");
@@ -327,11 +370,11 @@ public class GrandExchange {
         }
 
         MousePackets.queueClickPacket();
-        WidgetPackets.queueWidgetActionPacket(1, 30474265, -1, 7);
+        WidgetPackets.queueWidgetActionPacket(1, InterfaceID.GeOffers.SETUP_DESC, -1, 7);
     }
 
     private static Page getPage() {
-        Widget offerContainer = client.getWidget(ComponentID.GRAND_EXCHANGE_OFFER_CONTAINER);
+        Widget offerContainer = client.getWidget(InterfaceID.GeOffers.SETUP_DESC);
 
         if (offerContainer != null && !offerContainer.isHidden()) {
             String text = offerContainer.getChild(20).getText();
@@ -350,7 +393,7 @@ public class GrandExchange {
             return Page.UNKNOWN;
         }
 
-        Widget homeContainer = client.getWidget(ComponentID.GRAND_EXCHANGE_WINDOW_CONTAINER);
+        Widget homeContainer = client.getWidget(InterfaceID.GeOffers.CONTENTS);
 
         if (homeContainer != null && !homeContainer.isHidden()) {
             return Page.HOME;


### PR DESCRIPTION
BankItemWidget can 100% be simplified but this fixes bugs interacting with them under certain conditions.

GE Api was broken due to hardcoded IDs - we should eventually go over the rest of the api and avoid the use of hardcoded IDs where possible utilizing the gameval classes.  I'll do some inspection and see if there is anything that needs changing - but wanted to put this here so others can see and try to avoid hardcoding IDs in their plugins.